### PR TITLE
chore: update resources.html

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -95,7 +95,7 @@
       <li>101 Reasons to use Bitcoin: <a href="https://www.reasonstousebitcoin.com/use-bitcoin/" target="_blank">reasonstousebitcoin.com/use-bitcoin/</a></li>
       <li>Bitcoin obituaries: <a href="https://99bitcoins.com/bitcoin-obituaries/" target="_blank">99bitcoins.com/bitcoin-obituaries</a></li>
       <li>Bitcoin myths debunked: <a href="https://en.bitcoin.it/wiki/Myths" target="_blank">en.bitcoin.it/wiki/Myths</a></li>
-      <li>How dollar cost averaging Bitcoin has worked out in the past: <a href="https://dcabtc.com" target="_blank">dcabtc.com</a></li>
+      <li>How dollar cost averaging Bitcoin has worked out in the past: <a href="https://www.dca-cc.com/dca/bitcoin" target="_blank">dca-cc.com</a></li>
 
       <br>
 


### PR DESCRIPTION
Linking to [dca-cc.com](www.dca-cc.com) instead of [dcabtc.com](www.dcabtc.com).

Reasons:
- It is [open source](https://github.com/vladanpaunovic/dca-crypto)
- It is much better tool
- it is regularly maintained
- it is mine 😄 